### PR TITLE
30 user login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,7 @@
 class SessionsController < ApplicationController
-  def new; end
+  def new
+    redirect_to dashboard_path if current_user
+  end
 
   def create
     user = User.find_by(email: params[:email])

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,10 +7,10 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
   </head>
-  
-  <body>
-    <nav>
 
+  <body>
+    <nav class="main-nav">
+      <%= link_to "Login", "/login" unless current_user %>
       <%= link_to "Logout", "/logout", method: :delete if current_user %>
     </nav>
     <main>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,5 @@
 <h1>Register for Viewing Party</h1>
+<p class="current-user"><%= link_to 'Already a user? Login!', login_path %></p>
 <p>Password length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character.</p>
 <%= form_with model: @user, local: true do |f| %>
   <%= f.label :email %>

--- a/spec/features/sessions/destroy_spec.rb
+++ b/spec/features/sessions/destroy_spec.rb
@@ -11,9 +11,9 @@ describe 'logout' do
       visit "/login"
       fill_in 'email', with: 'testing@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
     end
-    
+
     it "when I click 'logout' I'm returned to the welcome page" do
       click_on("Logout")
       expect(current_path).to eq("/")
@@ -21,4 +21,3 @@ describe 'logout' do
     end
   end
 end
-    

--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -12,36 +12,36 @@ describe 'login' do
         visit "/"
       end
       it 'I can login' do
-        click_on 'Login'
+        click_button 'Login'
         expect(current_path).to eq("/login")
 
         fill_in 'email', with: 'testing@example.com'
         fill_in 'password', with: '1234**USAusa'
 
-        click_on "Login"
+        click_button 'Login'
         expect(current_path).to eq("/dashboard")
       end
 
       it 'I cannot login with invalid email' do
-        click_on 'Login'
+        click_button 'Login'
         expect(current_path).to eq("/login")
 
         fill_in 'email', with: 'user@example.com'
         fill_in 'password', with: '1234**USAusa'
 
-        click_on "Login"
+        click_button 'Login'
         expect(page).to have_content("Your email or password was incorrect!")
         expect(current_path).to eq("/login")
       end
 
       it 'I cannot login with invalid password' do
-        click_on 'Login'
+        click_button 'Login'
         expect(current_path).to eq("/login")
 
         fill_in 'email', with: 'testing@example.com'
         fill_in 'password', with: 'password'
 
-        click_on "Login"
+        click_button 'Login'
         expect(page).to have_content("Your email or password was incorrect!")
         expect(current_path).to eq("/login")
       end

--- a/spec/features/sessions/new_spec.rb
+++ b/spec/features/sessions/new_spec.rb
@@ -47,4 +47,21 @@ describe 'login' do
       end
     end
   end
+
+  describe 'As a logged in user' do
+    before :each do
+      @user = User.create(
+        email: 'testing@example.com',
+        password: '1234**USAusa',
+        password_confirmation: '1234**USAusa'
+      )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    it 'I get redirect to the dashboard if I visit the login page' do
+      visit login_path
+
+      expect(current_path).to eq(dashboard_path)
+    end
+  end
 end

--- a/spec/features/users/friends_spec.rb
+++ b/spec/features/users/friends_spec.rb
@@ -16,7 +16,7 @@ describe 'Friends' do
       visit "/login"
       fill_in 'email', with: 'testing@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
       visit '/dashboard'
     end
 
@@ -51,7 +51,7 @@ describe 'Friends' do
       visit "/login"
       fill_in 'email', with: 'friend@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
       visit '/dashboard'
 
       expect(page).to have_content(@user.email)

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe 'registration page' do
       visit '/registration'
     end
 
+    it 'I see a link to login on the page' do
+      within '.current-user' do
+        expect(page).to have_link('Already a user? Login!')
+      end
+    end
+
     it 'I can register as a new user' do
       fill_in 'user[email]', with: 'testing@example.com'
       fill_in 'user[password]', with: '1234**USAusa'

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -25,7 +25,7 @@ describe 'dashboard' do
       visit "/login"
       fill_in 'email', with: 'testing@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
       visit '/dashboard'
     end
 
@@ -36,6 +36,12 @@ describe 'dashboard' do
 
     it "I see a friends section" do
       expect(page).to have_css('.friends')
+    end
+
+    it 'I cannot see a login link in the nav' do
+      within('.main-nav') do
+        expect(page).to_not have_link('Login')
+      end
     end
 
     it "I can see a viewing parties section" do
@@ -68,7 +74,7 @@ describe 'dashboard' do
       visit "/login"
       fill_in 'email', with: 'friend1@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
 
       VCR.use_cassette('movie_detail_550_vp_request_generate') do
         movie_service = MovieService.new(550)
@@ -88,7 +94,7 @@ describe 'dashboard' do
         visit "/login"
         fill_in 'email', with: 'testing@example.com'
         fill_in 'password', with: '1234**USAusa'
-        click_on "Login"
+        click_button 'Login'
 
         within('.attendee-parties') do
           expect(page).to have_content("#{vp.movie.title} on #{vp.date.strftime('%m/%d/%y')}")

--- a/spec/features/viewing_parties/new_spec.rb
+++ b/spec/features/viewing_parties/new_spec.rb
@@ -26,7 +26,7 @@ describe 'from the viewing party page' do
       visit "/login"
       fill_in 'email', with: 'testing@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
     end
 
     it 'I see the movie title' do
@@ -100,7 +100,7 @@ describe 'from the viewing party page' do
         visit "/login"
         fill_in 'email', with: 'friend1@example.com'
         fill_in 'password', with: '1234**USAusa'
-        click_on "Login"
+        click_button 'Login'
 
         expect(page).to have_content("#{vp.movie.title} on #{vp.date.strftime('%m/%d/%y')}")
       end
@@ -149,7 +149,7 @@ describe 'from the viewing party page' do
       visit "/login"
       fill_in 'email', with: 'loser@example.com'
       fill_in 'password', with: '1234**USAusa'
-      click_on "Login"
+      click_button 'Login'
 
       VCR.use_cassette('movie_detail_550_vp_request_generate') do
         movie_service = MovieService.new(550)

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe 'welcome page' do
       expect(page).to have_content('A place to get your friends together to watch a movie.')
     end
 
-    it 'I see a button to login' do
+    it 'I see a button and link to login' do
       expect(page).to have_button('Login')
+      within('.main-nav') do
+        expect(page).to have_link('Login')
+      end
     end
 
     it 'I see a link to register' do


### PR DESCRIPTION
This includes a merge with main after George's path update. 

Closes #30 

Includes:
- If user is logged in and they visit login page, they are redirected to the dashboard.
- Adds login link to navigation and updates tests to ensure when we login a user in the test, we are clicking the login form button not the login link at the top. 
- Only shows login link in nav when it is a visitor
- Adds link to login on register page, just in case a user just suddenly remembers they have already signed up!